### PR TITLE
Mode option typo in narrative final energy graphs

### DIFF
--- a/src/UI/components/modes/Narrative.js
+++ b/src/UI/components/modes/Narrative.js
@@ -195,7 +195,7 @@ function Narrative() {
                     </div>
                 </div>
 
-                <FinalEnergyConsumptionBySource mode={"lines"} animation={false}/>
+                <FinalEnergyConsumptionBySource modeOption={"lines"} animation={false}/>
 
                 <div className="container my-3 my-md-5">
                     <div className="row">
@@ -207,7 +207,7 @@ function Narrative() {
                     </div>
                 </div>
 
-                <FinalEnergyConsumptionBySource mode={"doughnut"} animation={false}/>
+                <FinalEnergyConsumptionBySource modeOption={"doughnut"} animation={false}/>
 
                 <div className="container my-3 my-md-5">
                     <div className="row">


### PR DESCRIPTION
Hello!
Simple typo PR for the FinalEnergyConsumptionBySource graphs in narrative mode. Currently the last graph is not displayed as doughnut, due to the `mode` param name used instead of `modeOption`. See `src/UI/components/charts/FinalEnergyConsumptionBySource.js`.